### PR TITLE
Allow search.json generation separate from Swiftype upload

### DIFF
--- a/features/step_definitions/swiftype_steps.rb
+++ b/features/step_definitions/swiftype_steps.rb
@@ -1,0 +1,5 @@
+require "swiftype"
+
+Given /^Swiftype expects to receive new search records$/ do
+  expect_any_instance_of(::Swiftype::Client).to receive(:create_or_update_document).at_least(1).times
+end

--- a/features/swiftype_cli.feature
+++ b/features/swiftype_cli.feature
@@ -1,0 +1,7 @@
+Feature: Generating Swiftype manifest files
+  Scenario: Generating search.json for Swiftype with the CLI
+    Given a fixture app "swiftype-app"
+    And I run `middleman swiftype --only-generate`
+    Then the exit status should be 0
+    And the following files should exist:
+      | build/search.json |

--- a/fixtures/swiftype-app/config.rb
+++ b/fixtures/swiftype-app/config.rb
@@ -1,0 +1,9 @@
+activate :swiftype do |swiftype|
+  swiftype.api_key = "API_KEY"
+  swiftype.engine_slug = "middleman"
+  swiftype.pages_selector = lambda { |p| p.path.match(/\.html/) && p.metadata[:options][:layout] == nil }
+  swiftype.process_html = lambda { |f| f.search('.//div[@class="linenodiv"]').remove }
+  swiftype.generate_sections = lambda { |p| (p.metadata[:page]['tags'] ||= []) + (p.metadata[:page]['categories'] ||= []) }
+  swiftype.generate_info = lambda { |f| f.to_s }
+  swiftype.generate_image = lambda { |p| "#{settings.url}#{p.metadata[:page]['banner']}" if p.metadata[:page]['banner'] }
+end

--- a/fixtures/swiftype-app/source/index.html
+++ b/fixtures/swiftype-app/source/index.html
@@ -1,0 +1,1 @@
+The quick brown fox jumps over the lazy dogs.


### PR DESCRIPTION
Inspired by https://github.com/emberjs/guides/issues/2. Adds a command-line flag `--only-generate` to `middleman swiftype` that will place `search.json` in the `source/` directory.

Also starts to add testing around Swiftype upload functionality. These are tagged with `@wip` because I couldn't seem to stub out `Swiftype::Client` while executing it via the Cucumber steps.
