### PR TITLE
Allow customizable title via config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ activate :swiftype do |swiftype|
   swiftype.process_html = lambda { |f| f.search('.//div[@class="linenodiv"]').remove }
   swiftype.generate_sections = lambda { |p| (p.metadata[:page]['tags'] ||= []) + (p.metadata[:page]['categories'] ||= []) }
   swiftype.generate_info = lambda { |f| TruncateHTML.truncate_html(strip_img(f.to_s), blog.options.summary_length, '...') }
-  swiftype.exclude_empty_titles = true
+  swiftype.should_index = lamda { |p, title| '...' }
 end
 ```
 
@@ -44,4 +44,4 @@ The `title_selector` can be used to look up a page's title (for each page). For 
 
 `generate_info` is an option that can be used for anything. _I_ use it for storing the summary of each post.
 
-`exclude_empty_titles` will skip indexing resources which do not have a title if set to true
+`should_index` can be used to filter out pages that you don't want to index. Return true to index in swiftype, false to skip.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ activate :swiftype do |swiftype|
   swiftype.process_html = lambda { |f| f.search('.//div[@class="linenodiv"]').remove }
   swiftype.generate_sections = lambda { |p| (p.metadata[:page]['tags'] ||= []) + (p.metadata[:page]['categories'] ||= []) }
   swiftype.generate_info = lambda { |f| TruncateHTML.truncate_html(strip_img(f.to_s), blog.options.summary_length, '...') }
+  swiftype.exclude_empty_titles = true
 end
 ```
 
@@ -42,3 +43,5 @@ The `title_selector` can be used to look up a page's title (for each page). For 
 `generate_sections` can be used for search keywords you want to use but are not in the main content. I base mine on the categories & tags for a post.
 
 `generate_info` is an option that can be used for anything. _I_ use it for storing the summary of each post.
+
+`exclude_empty_titles` will skip indexing resources which do not have a title if set to true

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ activate :swiftype do |swiftype|
   swiftype.api_key = 'MY_SECRET_API_KEY'
   swiftype.engine_slug = 'my_awesome_blog'
   swiftype.pages_selector = lambda { |p| p.path.match(/\.html/) && p.metadata[:options][:layout] == nil }
+  swiftype.title_selector = lamda { |mm_instance, p| '...' }
   swiftype.process_html = lambda { |f| f.search('.//div[@class="linenodiv"]').remove }
   swiftype.generate_sections = lambda { |p| (p.metadata[:page]['tags'] ||= []) + (p.metadata[:page]['categories'] ||= []) }
   swiftype.generate_info = lambda { |f| TruncateHTML.truncate_html(strip_img(f.to_s), blog.options.summary_length, '...') }
@@ -33,6 +34,8 @@ end
 The api key and engine slug can be found in the swiftype dashboard.
 
 The `pages_selector` can be used to filter the pages that are searchable. If this option is not used all pages will be searched. So this will include any rss or atom feeds generated.
+
+The `title_selector` can be used to look up a page's title (for each page). For example, maybe you store the titles in a customized table of contents file.
 
 `process_html` can be used for transforming the html content that will be send to swiftype. In my example I'm using this to remove line numbers in code blocks: I don't want them to be searchable by swiftype.
 

--- a/lib/middleman-swiftype/commands.rb
+++ b/lib/middleman-swiftype/commands.rb
@@ -141,7 +141,7 @@ EOF
           fields = [
             {:name => 'title', :value => title, :type => 'string'},
             {:name => 'url', :value => url, :type => 'enum'},
-            {:name => 'body', :value => body, :type => 'text'},
+            {:name => 'body', :value => body, :type => 'string'},
             {:name => 'info', :value => info, :type => 'string'}
           ]
 

--- a/lib/middleman-swiftype/commands.rb
+++ b/lib/middleman-swiftype/commands.rb
@@ -59,6 +59,7 @@ activate :swiftype do |swiftype|
   swiftype.api_key = 'MY_SECRET_API_KEY'
   swiftype.engine_slug = 'my_awesome_blog'
   swiftype.pages_selector = lambda { |p| p.path.match(/\.html/) && p.metadata[:options][:layout] == nil }
+  swiftype.title_selector = lamda { |mm_instance, p| '...' }
   swiftype.process_html = lambda { |f| f.search('.//div[@class="linenodiv"]').remove }
   swiftype.generate_sections = lambda { |p| (p.metadata[:page]['tags'] ||= []) + (p.metadata[:page]['categories'] ||= []) }
   swiftype.generate_info = lambda { |f| TruncateHTML.truncate_html(strip_img(f.to_s), blog.options.summary_length, '...') }

--- a/lib/middleman-swiftype/commands.rb
+++ b/lib/middleman-swiftype/commands.rb
@@ -93,31 +93,6 @@ EOF
         options
       end
 
-      def current_guide(current_page)
-        path = current_page.path.gsub('.html', '')
-        guide_path = path.split("/")[0]
-
-        current_guide = shared_instance.data.guides.find do |guide|
-          guide.url == guide_path
-        end
-
-        current_guide
-      end
-
-      def current_chapter(current_page)
-        guide = current_guide(current_page)
-        return unless guide
-
-        path = current_page.path.gsub('.html', '')
-        chapter_path = path.split('/')[1..-1].join('/')
-
-        current_chapter = guide.chapters.find do |chapter|
-          chapter.url == chapter_path
-        end
-
-        current_chapter
-      end
-
       def generate_swiftype_records
         records = []
 
@@ -126,11 +101,12 @@ EOF
 
         m_pages.each do |p|
           external_id = Digest::MD5.hexdigest(p.url)
-          title = p.metadata[:page]['title']
 
+          # optional selector for retrieving the page title
           if options.title_selector
-            chapter = current_chapter(p)
-            title = chapter.title
+            title = options.title_selector.call(shared_instance, p)
+          else
+            title = p.metadata[:page]['title']
           end
 
           url = p.url

--- a/lib/middleman-swiftype/commands.rb
+++ b/lib/middleman-swiftype/commands.rb
@@ -33,9 +33,10 @@ module Middleman
 
       def swiftype
         if options[:"only-generate"]
-          Dir.mkdir('./build') unless File.exist?('./build')
-          File.delete('./build/search.json') if File.exist?('./build/search.json')
-          File.open("./build/search.json", "w") do |f|
+          build_dir = ::Middleman::Application.build_dir
+          Dir.mkdir("./#{build_dir}") unless File.exist?("./#{build_dir}")
+          File.delete("./#{build_dir}/search.json") if File.exist?("./#{build_dir}/search.json")
+          File.open("./#{build_dir}/search.json", "w") do |f|
             f.write(self.generate_swiftype_records.to_json)
           end
         else
@@ -64,7 +65,7 @@ end
 EOF
       end
 
-      def swiftype_options(shared_instance)
+      def swiftype_options(shared_instance, generate_only=false)
         require 'swiftype'
         require 'nokogiri'
         require 'digest'
@@ -76,6 +77,8 @@ EOF
         rescue
           print_usage_and_die "You need to activate the swiftype extension in config.rb."
         end
+
+        return options if generate_only
 
         if (!options.api_key)
           print_usage_and_die "The swiftype extension requires you to set an api_key."
@@ -91,7 +94,7 @@ EOF
       def generate_swiftype_records
         records = []
 
-        options = self.swiftype_options(shared_instance)
+        options = self.swiftype_options(shared_instance, true)
         m_pages = shared_instance.sitemap.resources.find_all{|p| options.pages_selector.call(p) }
 
         m_pages.each do |p|

--- a/lib/middleman-swiftype/commands.rb
+++ b/lib/middleman-swiftype/commands.rb
@@ -66,7 +66,7 @@ activate :swiftype do |swiftype|
   swiftype.generate_sections = lambda { |p| (p.metadata[:page]['tags'] ||= []) + (p.metadata[:page]['categories'] ||= []) }
   swiftype.generate_info = lambda { |f| TruncateHTML.truncate_html(strip_img(f.to_s), blog.options.summary_length, '...') }
   swiftype.generate_image = lambda { |p| "#{settings.url}#{p.metadata[:page]['banner']}" if p.metadata[:page]['banner'] }
-  swiftype.exclude_empty_titles = true
+  swiftype.should_index = lamda { |p, title| '...' }
 end
 EOF
       end
@@ -113,8 +113,6 @@ EOF
             title = p.metadata[:page]['title']
           end
 
-          next if options.exclude_empty_titles and title.to_s == ''
-
           url = p.url
           sections = []
           body = ''
@@ -141,6 +139,11 @@ EOF
           # optional image
           if options.generate_image
             image = options.generate_image.call(p)
+          end
+
+          if options.should_index
+            should_index = options.should_index.call(p, title)
+            next unless should_index
           end
 
           fields = [

--- a/lib/middleman-swiftype/commands.rb
+++ b/lib/middleman-swiftype/commands.rb
@@ -66,6 +66,7 @@ activate :swiftype do |swiftype|
   swiftype.generate_sections = lambda { |p| (p.metadata[:page]['tags'] ||= []) + (p.metadata[:page]['categories'] ||= []) }
   swiftype.generate_info = lambda { |f| TruncateHTML.truncate_html(strip_img(f.to_s), blog.options.summary_length, '...') }
   swiftype.generate_image = lambda { |p| "#{settings.url}#{p.metadata[:page]['banner']}" if p.metadata[:page]['banner'] }
+  swiftype.exclude_empty_titles = true
 end
 EOF
       end
@@ -111,6 +112,8 @@ EOF
           else
             title = p.metadata[:page]['title']
           end
+
+          next if options.exclude_empty_titles and title.to_s == ''
 
           url = p.url
           sections = []

--- a/lib/middleman-swiftype/commands.rb
+++ b/lib/middleman-swiftype/commands.rb
@@ -39,7 +39,9 @@ module Middleman
 
           shared_instance.logger.info("Done. Creating search.json...")
           File.open("./#{Middleman::Application.build_dir}/search.json", "w") do |f|
+            f.write("{\"documents\": ")
             f.write(self.generate_swiftype_records.to_json)
+            f.write("}")
           end
         else
           self.push_to_swiftype(self.generate_swiftype_records)

--- a/lib/middleman-swiftype/extension.rb
+++ b/lib/middleman-swiftype/extension.rb
@@ -5,7 +5,7 @@ require "middleman-core"
 module Middleman
   module Swiftype
 
-    class Options < Struct.new(:api_key, :engine_slug, :pages_selector, :process_html, :generate_sections, :generate_info, :generate_image, :title_selector); end
+    class Options < Struct.new(:api_key, :engine_slug, :pages_selector, :process_html, :generate_sections, :generate_info, :generate_image, :title_selector, :exclude_empty_titles); end
 
     class << self
       def registered(app, options_hash={}, &block)

--- a/lib/middleman-swiftype/extension.rb
+++ b/lib/middleman-swiftype/extension.rb
@@ -5,7 +5,7 @@ require "middleman-core"
 module Middleman
   module Swiftype
 
-    class Options < Struct.new(:api_key, :engine_slug, :pages_selector, :process_html, :generate_sections, :generate_info, :generate_image, :title_selector, :exclude_empty_titles); end
+    class Options < Struct.new(:api_key, :engine_slug, :pages_selector, :process_html, :generate_sections, :generate_info, :generate_image, :title_selector, :should_index); end
 
     class << self
       def registered(app, options_hash={}, &block)

--- a/lib/middleman-swiftype/extension.rb
+++ b/lib/middleman-swiftype/extension.rb
@@ -5,7 +5,7 @@ require "middleman-core"
 module Middleman
   module Swiftype
 
-    class Options < Struct.new(:api_key, :engine_slug, :pages_selector, :process_html, :generate_sections, :generate_info, :generate_image); end
+    class Options < Struct.new(:api_key, :engine_slug, :pages_selector, :process_html, :generate_sections, :generate_info, :generate_image, :title_selector); end
 
     class << self
       def registered(app, options_hash={}, &block)


### PR DESCRIPTION
This adds a new title_selector config option. If used, it'll be executed to search and find the title.

We have a table of contents file and need the ability to search it ourselves to get the title.  I've tested this against the ember\guides repo and it works great :)

Updated this repo's README and the example usage
